### PR TITLE
Add basic theme system

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -6,7 +6,7 @@ import React from 'react';
 
 import AppEnvironment from 'templates/AppEnvironment';
 
-export function wrapRootElement({ element }) {
+export function wrapPageElement({ element }) {
   return (
     <AppEnvironment>
       {element}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4997,6 +4997,16 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
+    "emotion-theming": {
+      "version": "10.0.14",
+      "resolved": "https://registry.npmjs.org/emotion-theming/-/emotion-theming-10.0.14.tgz",
+      "integrity": "sha512-zMGhPSYz48AAR6DYjQVaZHeO42cYKPq4VyB1XjxzgR62/NmO99679fx8qDDB1QZVYGkRWZtsOe+zJE/e30XdbA==",
+      "requires": {
+        "@babel/runtime": "^7.4.3",
+        "@emotion/weak-memoize": "0.2.3",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@emotion/core": "^10.0.14",
     "@emotion/styled": "^10.0.14",
     "cosmiconfig": "^5.2.1",
+    "emotion-theming": "^10.0.14",
     "gatsby": "^2.13.41",
     "gatsby-image": "^2.2.7",
     "gatsby-plugin-google-analytics": "^2.1.4",
@@ -67,7 +68,8 @@
         "github": "https://github.com/ENvironmentSet",
         "twitter": "https://twitter.com/NvironmentE"
       },
-      "something": "？"
+      "something": "？",
+      "theme": "github"
     },
     "useIcon": false
   }

--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
         "github": "https://github.com/ENvironmentSet",
         "twitter": "https://twitter.com/NvironmentE"
       },
-      "something": "？",
-      "useIcon": false
-    }
+      "something": "？"
+    },
+    "useIcon": false
   }
 }

--- a/src/components/atoms/Accent.js
+++ b/src/components/atoms/Accent.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
-import { accentColor } from 'constants/palette';
+import { pickColor } from 'constants/themes';
 
 export default styled.strong`
-  color: ${accentColor};
+  color: ${pickColor('accent')};
 `;

--- a/src/components/atoms/HyperLink.js
+++ b/src/components/atoms/HyperLink.js
@@ -3,13 +3,13 @@ import styled from '@emotion/styled';
 
 import { Link as GatsbyLink } from 'gatsby';
 
-import { hyperLinkColor } from 'constants/palette';
+import { pickColor } from 'constants/themes';
 
 export default function HyperLink({ to, children }) {
   const LinkStyle = styled.div`
      box-shadow: none;
      text-decoration: none;
-     color: ${hyperLinkColor};
+     color: ${pickColor('hyperLink')};
    `;
   function isInternalLink(link) {
     const regexp = /^\/(?!\/)/;

--- a/src/components/atoms/Markdown.js
+++ b/src/components/atoms/Markdown.js
@@ -1,21 +1,21 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import { hyperLinkColor, textColor, accentColor } from 'constants/palette';
+import { pickColor } from 'constants/themes';
 
 export default function Markdown({ children }) {
   const MarkdownContainer = styled.div`
       a {
-        color: ${hyperLinkColor};
+        color: ${pickColor('hyperLink')};
       }
       p, span, small, h1, h2, h3, h4, h5, h6 {
-        color: ${textColor};
+        color: ${pickColor('foreground')};
       }
       strong {
-        color: ${accentColor}
+        color: ${pickColor('accent')}
       }
       hr {
-        background-color: ${textColor};
+        background-color: ${pickColor('foreground')};
       }
   `;
 

--- a/src/components/atoms/Text.js
+++ b/src/components/atoms/Text.js
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 
-import { textColor } from 'constants/palette';
+import { pickColor } from 'constants/themes';
 
 export const Text = styled.p`
-  color: ${textColor};
+  color: ${pickColor('foreground')};
 `;
 export default Text;
 export const H1Text = Text.withComponent('h1');

--- a/src/components/atoms/ThematicBreak.js
+++ b/src/components/atoms/ThematicBreak.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
-import { textColor } from 'constants/palette';
+import { pickColor } from 'constants/themes';
 
 export default styled.hr`
-  background-color: ${textColor};
+  background-color: ${pickColor('foreground')};
 `;

--- a/src/constants/palette.js
+++ b/src/constants/palette.js
@@ -1,4 +1,0 @@
-export const hyperLinkColor = '#80CBC4';
-export const backgroundColor = '#212121';
-export const textColor = '#B0BEC5';
-export const accentColor = '#FF9800';

--- a/src/constants/themes.js
+++ b/src/constants/themes.js
@@ -1,0 +1,42 @@
+class Theme {
+  constructor(backgroundColor, textColor, accentColor, hyperLinkColor) {
+    this.backgroundColor = backgroundColor;
+    this.foregroundColor = textColor;
+    this.accentColor = accentColor;
+    this.hyperLinkColor = hyperLinkColor;
+  }
+}
+
+const oceanic = new Theme('#263238','#B0BEC5', '#009688', '#80cbc4');
+const darker = new Theme('#212121', '#B0BEC5', '#FF9800', '#80cbc4');
+const lighter = new Theme('#FAFAFA', '#546E7A', '#00BCD4', '#39ADB5');
+const palenight = new Theme('#292D3E', '#A6ACCD', '#AB47BC', '#80CBC4');
+const deepOcean = new Theme('#0F111A', '#8F93A2', '#84FFFF', '#80CBC4');
+const monokaiPro = new Theme('#2D2A2E', '#FCFCFA', '#FFD866', '#78DCE8');
+const dracula = new Theme('#282A36', '#F8F8F2', '#FF79C5', '#F1FA8C');
+const github = new Theme('#F7F8FA', '#5B6168', '#79CB60', '#005CC5');
+const arcDark = new Theme('#2F343F', '#D3DAE3', '#42A5F5', '#7587A6');
+const oneDark = new Theme('#282C34', '#979FAD', '#2979FF', '#56B6C2');
+const oneLight = new Theme('#FAFAFA', '#232324', '#2979FF', '#0184BC');
+const solarizedDark = new Theme('#002B36', '#839496', '#D33682', '#268BD2');
+const solarizedLight = new Theme('#FDF6E3', '#586E75', '#D33682', '#268BD2');
+
+export default {
+  oceanic,
+  darker,
+  lighter,
+  palenight,
+  deepOcean,
+  monokaiPro,
+  dracula,
+  github,
+  arcDark,
+  oneDark,
+  oneLight,
+  solarizedDark,
+  solarizedLight
+};
+
+export function pickColor(kind) {
+  return ({ theme }) => theme[`${kind}Color`];
+};

--- a/src/templates/AppEnvironment.js
+++ b/src/templates/AppEnvironment.js
@@ -1,21 +1,28 @@
 import React from 'react';
-import { Global, css } from '@emotion/core';
 
-import { backgroundColor } from 'constants/palette';
+import { Global, css } from '@emotion/core';
+import { ThemeProvider } from 'emotion-theming';
+
+import useSiteMetadata from 'utils/useSiteMetadata';
+
+import themes from 'constants/themes';
 
 export default function AppEnvironment({ children }) {
+  const { theme: selectedTheme } = useSiteMetadata();
+  const theme = themes[selectedTheme];
+
   return (
-    <>
+    <ThemeProvider theme={theme}>
       <Global
         styles={
           css`
            :root {
-              background-color: ${backgroundColor};
+              background-color: ${theme.backgroundColor};
             }
           `
         }
       />
       {children}
-    </>
+    </ThemeProvider>
   );
 };

--- a/src/utils/useSiteMetadata.js
+++ b/src/utils/useSiteMetadata.js
@@ -14,6 +14,7 @@ export default function useSiteMetadata() {
             twitter
           }
           something
+          theme
         }
       }
     }


### PR DESCRIPTION
Adds basic theme system

Features:

- Basically, now we can choose theme of blog in config file via 'siteMetadata.theme'.
- 12 built-in theme is ready

Known Limitations:

- Adding custom theme is not implemented yet, but don't be disappointed I will work on it. before my work, there is only one way to define custom theme. create `Theme` object and export it through default export in `constants/themes`. and then specify that object in configuration.
- Changing theme doesn't change syntax highlighting of code in rendered Markdown.
   I've found few solutions and I'm considering these solutions now. but I'll not include chosen solution in this PR, I'll make another PR for it(because this task would take so much time and effort.)